### PR TITLE
chore: use final OZ EIP712 impl

### DIFF
--- a/src/Boost.sol
+++ b/src/Boost.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.15;
 
 import "openzeppelin-contracts/access/Ownable.sol";
 import "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
-import "openzeppelin-contracts/utils/cryptography/draft-EIP712.sol";
+import "openzeppelin-contracts/utils/cryptography/EIP712.sol";
 import "openzeppelin-contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/test/Boost.t.sol
+++ b/test/Boost.t.sol
@@ -6,7 +6,7 @@ import "./mocks/MockERC20.sol";
 import "../src/Boost.sol";
 import { GasSnapshot } from "forge-gas-snapshot/GasSnapshot.sol";
 
-abstract contract BoostTest is Test, GasSnapshot, EIP712("boost", "1") {
+abstract contract BoostTest is Test, GasSnapshot {
     event Mint(uint256 boostId, IBoost.BoostConfig boost);
     event Claim(IBoost.ClaimConfig claim);
     event Deposit(uint256 boostId, address sender, uint256 amount);


### PR DESCRIPTION
Previously we were using the draft version which has been depreciated, so we update to the Final version